### PR TITLE
[feat] Enable the dispatcher mode

### DIFF
--- a/fixbackend/config.py
+++ b/fixbackend/config.py
@@ -36,7 +36,7 @@ class Config(BaseSettings):
     redis_readwrite_url: str
     redis_readonly_url: str
     redis_queue_url: str
-    cdn_enpoint: str
+    cdn_endpoint: str
     cdn_bucket: str
     fixui_sha: str
     static_assets: Optional[Path]
@@ -44,14 +44,18 @@ class Config(BaseSettings):
     available_db_server: List[str]
     inventory_url: str
     cf_template_url: str
+    args: Namespace
 
     def frontend_cdn_origin(self) -> str:
-        return f"{self.cdn_enpoint}/{self.cdn_bucket}/{self.fixui_sha}"
+        return f"{self.cdn_endpoint}/{self.cdn_bucket}/{self.fixui_sha}"
 
     @property
     def database_url(self) -> str:
         password = f":{self.database_password}" if self.database_password else ""
         return f"mysql+aiomysql://{self.database_user}{password}@{self.database_host}:{self.database_port}/{self.database_name}"  # noqa
+
+    class Config:
+        extra = "ignore"  # allow extra fields in the config
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> Namespace:
@@ -77,7 +81,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> Namespace:
     )
     parser.add_argument("--redis-queue-url", default=os.environ.get("REDIS_QUEUE_URL", "redis://localhost:6379/5"))
     parser.add_argument("--skip-migrations", default=False, action="store_true")
-    parser.add_argument("--cdn-enpoint", default=os.environ.get("FIXUI_CDN_ENDPOINT", "https://cdn.some.engineering"))
+    parser.add_argument("--cdn-endpoint", default=os.environ.get("FIXUI_CDN_ENDPOINT", "https://cdn.some.engineering"))
     parser.add_argument("--cdn-bucket", default=os.environ.get("FIXUI_CDN_BUCKET", "fix-ui"))
     parser.add_argument("--fixui-sha", default=os.environ.get("FIXUI_SHA", ""))
     parser.add_argument("--static-assets", type=Path, default=os.environ.get("STATIC_ASSETS"))
@@ -90,14 +94,18 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> Namespace:
         "--cf-template-url",
         default=os.environ.get("CF_TEMPLATE_URL", "https://fixpublic.s3.amazonaws.com/aws/fix-role-dev-eu.yaml"),
     )
+    parser.add_argument(
+        "--dispatcher", action="store_true", default=False, help="Run the dispatcher instead of the web server"
+    )
 
     return parser.parse_known_args(argv if argv is not None else sys.argv[1:])[0]
 
 
 def get_config(argv: Optional[Sequence[str]] = None) -> Config:
     args = parse_args(argv)
-    delattr(args, "skip_migrations")  # this is not a valid config option
-    return Config(**vars(args))
+    args_dict = vars(args)
+    args_dict["args"] = args
+    return Config(**args_dict)
 
 
 # placeholder for dependencies, will be replaced during the app initialization

--- a/tests/fixbackend/conftest.py
+++ b/tests/fixbackend/conftest.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import json
+from argparse import Namespace
 from asyncio import AbstractEventLoop
 from typing import Iterator, AsyncIterator, List
 
@@ -65,7 +66,7 @@ def default_config() -> Config:
         redis_readwrite_url="redis://localhost:6379/0",
         redis_readonly_url="redis://localhost:6379/0",
         redis_queue_url="redis://localhost:6379/5",
-        cdn_enpoint="",
+        cdn_endpoint="",
         cdn_bucket="",
         fixui_sha="",
         static_assets=None,
@@ -73,6 +74,7 @@ def default_config() -> Config:
         available_db_server=["http://localhost:8529", "http://127.0.0.1:8529"],
         inventory_url="http://localhost:8980",
         cf_template_url="dev-eu",
+        args=Namespace(dispatcher=False),
     )
 
 


### PR DESCRIPTION
# Description

Starting `fixbackend --dispatcher` will start the backend in dispatching mode.
The API that is provided has /ready /healthy and /metrics but not the /api endpoints.
It allows starting different background tasks than in API mode.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `nox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
