### PR TITLE
Refactor assert -> fassert

### DIFF
--- a/fixbackend/auth/api_token_service.py
+++ b/fixbackend/auth/api_token_service.py
@@ -38,7 +38,7 @@ from fixbackend.errors import NotAllowed
 from fixbackend.ids import WorkspaceId
 from fixbackend.permissions.models import all_permissions
 from fixbackend.types import AsyncSessionMaker
-from fixbackend.utils import uid
+from fixbackend.utils import uid, fassert
 from fixbackend.workspaces.repository import WorkspaceRepository
 
 
@@ -63,7 +63,7 @@ class ApiTokenService(Service):
     async def login(self, api_token: str) -> str:
         tkn = await self._get_user_token(api_token, update_last_used=True)
         user = await self.user_repo.get(tkn.user_id)
-        assert user, "User not found"
+        fassert(user, "User not found")
         permission = tkn.permission or all_permissions
         workspace = tkn.workspace_id
         permissions = {
@@ -81,7 +81,7 @@ class ApiTokenService(Service):
             token_hash = self.password_helper.hash(token)
             if workspace_id:
                 ids = {ws.id for ws in await self.workspace_repo.list_workspaces(user)}
-                assert workspace_id in ids, "User is not a member of the workspace"
+                fassert(workspace_id in ids, "User is not a member of the workspace")
             async with self.session_maker() as session:
                 now = utc()
                 entity = ApiTokenEntity(

--- a/fixbackend/auth/user_verifier.py
+++ b/fixbackend/auth/user_verifier.py
@@ -20,6 +20,7 @@ from fastapi.datastructures import URL
 
 from fixbackend.auth.models import User
 from fixbackend.config import Config
+from fixbackend.utils import fassert
 from fixbackend.dependencies import FixDependency, ServiceNames
 from fixbackend.notification.email.email_messages import PasswordReset, VerifyEmail
 from fixbackend.notification.notification_service import NotificationService
@@ -51,7 +52,7 @@ class AuthEmailSender:
         log.info(f"Sent account verification email to {user.email}")
 
     async def send_password_reset(self, user: User, token: str, request: Optional[Request]) -> None:
-        assert request
+        fassert(request, "Request is required to send password reset email")
 
         redirect_url = request.query_params.get("redirectUrl", "/")
         reset_link = request.base_url

--- a/fixbackend/certificates/cert_store.py
+++ b/fixbackend/certificates/cert_store.py
@@ -28,6 +28,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPubl
 from cryptography.x509 import Certificate
 
 from fixbackend.config import Config
+from fixbackend.utils import fassert
 
 
 @frozen
@@ -94,8 +95,8 @@ class CertificateStore:
         self.signing_key_2_path = config.signing_key_2
 
     async def get_host_cert_key_pair(self) -> CertKeyPair:
-        assert self.host_cert_path is not None
-        assert self.host_key_path is not None
+        fassert(self.host_cert_path is not None, "Host cert path not set")
+        fassert(self.host_key_path is not None, "Host key path not set")
         return await load_cert_key_pair(self.host_cert_path, self.host_key_path)
 
     async def _get_signing_cert_key_pair(self) -> List[CertKeyPair]:

--- a/fixbackend/cloud_accounts/service_impl.py
+++ b/fixbackend/cloud_accounts/service_impl.py
@@ -84,7 +84,7 @@ from fixbackend.logging_context import set_cloud_account_id, set_fix_cloud_accou
 from fixbackend.notification.email import email_messages as email
 from fixbackend.notification.notification_service import NotificationService
 from fixbackend.sqs import SQSRawListener
-from fixbackend.utils import uid
+from fixbackend.utils import uid, fassert
 from fixbackend.workspaces.models import Workspace
 from fixbackend.workspaces.repository import WorkspaceRepository
 
@@ -265,8 +265,8 @@ class CloudAccountServiceImpl(CloudAccountService, Service):
                 external_id = ExternalId(uuid.UUID(resource_properties["ExternalId"]))
                 role_name = AwsRoleName(resource_properties["RoleName"])
                 stack_id = resource_properties["StackId"]
-                assert stack_id.startswith("arn:aws:cloudformation:")
-                assert stack_id.count(":") == 5
+                fassert(stack_id.startswith("arn:aws:cloudformation:"), "Invalid stack id")
+                fassert(stack_id.count(":") == 5, "Invalid stack id")
                 account_id = CloudAccountId(stack_id.split(":")[4])
             except Exception as e:  # pragma: no cover
                 log.warning(f"Received invalid CF stack create event: {msg}. Error: {e}")

--- a/fixbackend/inventory/inventory_client.py
+++ b/fixbackend/inventory/inventory_client.py
@@ -51,6 +51,8 @@ from fixbackend.errors import ClientError
 from fixbackend.graph_db.models import GraphDatabaseAccess
 from fixbackend.ids import CloudAccountId, NodeId
 from fixbackend.inventory.schemas import CompletePathRequest, HistoryChange
+from fixbackend.utils import fassert
+
 
 T = TypeVar("T")
 ContextHeaders = {"Total-Count", "Result-Count"}
@@ -124,7 +126,7 @@ class InventoryClient(Service):
         if expected_media_types is not None and not response.is_error:
             media_type, *params = response.headers.get("content-type", "").split(";")
             emt = {expected_media_types} if isinstance(expected_media_types, str) else expected_media_types
-            assert media_type in emt, f"Expected content type {expected_media_types}, but got {media_type}"
+            fassert(media_type in emt, f"Expected content type {expected_media_types}, but got {media_type}")
 
     async def _request(
         self,

--- a/fixbackend/inventory/inventory_service.py
+++ b/fixbackend/inventory/inventory_service.py
@@ -64,8 +64,8 @@ from fixbackend.domain_events.events import (
 from fixbackend.domain_events.subscriber import DomainEventSubscriber
 from fixbackend.graph_db.models import GraphDatabaseAccess
 from fixbackend.graph_db.service import GraphDatabaseAccessManager
-from fixbackend.ids import TaskId, WorkspaceId
-from fixbackend.ids import NodeId
+from fixbackend.ids import TaskId, WorkspaceId, NodeId
+from fixbackend.utils import fassert
 from fixbackend.inventory.inventory_client import (
     InventoryClient,
     AsyncIteratorWithContext,
@@ -428,7 +428,7 @@ class InventoryService(Service):
                     ": sum(1) as count | dump",
                 ) as result:
                     async for elem in result:
-                        assert isinstance(elem, dict), f"Expected Json object but got {elem}"
+                        fassert(isinstance(elem, dict), f"Expected Json object but got {elem}")
                         severity = elem["group"]["severity"]
                         if severity is None:  # safeguard for history entries in old format
                             continue

--- a/fixbackend/notification/email/scheduled_email.py
+++ b/fixbackend/notification/email/scheduled_email.py
@@ -37,7 +37,7 @@ from fixbackend.notification.email.status_update_email_creator import StatusUpda
 from fixbackend.notification.user_notification_repo import UserNotificationSettingsEntity
 from fixbackend.sqlalechemy_extensions import UTCDateTime
 from fixbackend.types import AsyncSessionMaker
-from fixbackend.utils import uid
+from fixbackend.utils import uid, fassert
 from fixbackend.workspaces.models import Workspace
 from fixbackend.workspaces.models.orm import Organization, OrganizationMembers
 
@@ -129,7 +129,7 @@ class ScheduledEmailSender(Service):
                     try:
                         if last_workspace != workspace:
                             send_fn = await self.status_update_creator.create_messages_fn(workspace, now, duration)
-                        assert send_fn is not None, "Send function not set for workspace"
+                        fassert(send_fn is not None, "Send function not set for workspace")
                         subject, html, txt, images = send_fn(user)
                         await self.email_sender.send_email(
                             to=user.email,

--- a/fixbackend/notification/email/status_update_email_creator.py
+++ b/fixbackend/notification/email/status_update_email_creator.py
@@ -25,6 +25,8 @@ from fixbackend.inventory.inventory_service import InventoryService
 from fixbackend.inventory.schemas import Scatters
 from fixbackend.notification.email.email_messages import render
 from fixbackend.workspaces.models import Workspace
+from fixbackend.utils import fassert
+
 
 color_codes = [
     "#B7B8D3",  # Light Periwinkle
@@ -114,7 +116,7 @@ class StatusUpdateEmailCreator:
         self, workspace: Workspace, now: datetime, duration: timedelta
     ) -> Tuple[Dict[str, Any], Dict[str, bytes]]:
         dba = await self.db_access.get_database_access(workspace.id)
-        assert dba is not None, f"No database access for workspace: {workspace.id}"
+        fassert(dba is not None, f"No database access for workspace: {workspace.id}")
         duration_name = "month" if duration.days > 27 else "week"
         start = now - duration
 

--- a/fixbackend/subscription/aws_marketplace.py
+++ b/fixbackend/subscription/aws_marketplace.py
@@ -48,7 +48,7 @@ from fixbackend.subscription.models import AwsMarketplaceSubscription
 from fixbackend.subscription.subscription_repository import (
     SubscriptionRepository,
 )
-from fixbackend.utils import start_of_next_period
+from fixbackend.utils import start_of_next_period, fassert
 from fixbackend.workspaces.repository import WorkspaceRepository
 
 log = logging.getLogger(__name__)
@@ -183,7 +183,7 @@ class AwsMarketplaceHandler(Service):
 
     async def subscription_canceled(self, customer_id: str) -> None:
         async for subscription in self.subscription_repo.subscriptions(aws_customer_identifier=customer_id):
-            assert isinstance(subscription, AwsMarketplaceSubscription), "Subscription is not from AWS Marketplace"
+            fassert(isinstance(subscription, AwsMarketplaceSubscription), "Subscription is not from AWS Marketplace")
             await self.domain_event_sender.publish(SubscriptionCancelled(subscription.id, "aws_marketplace"))
             if billing := await self.billing_entry_service.create_billing_entry(subscription):
                 await self.report_usage(subscription.product_code, [(subscription, billing)])

--- a/fixbackend/subscription/router.py
+++ b/fixbackend/subscription/router.py
@@ -32,6 +32,7 @@ from fixbackend.permissions.permission_checker import WorkspacePermissionChecker
 from fixbackend.subscription.aws_marketplace import AwsMarketplaceHandlerDependency
 from fixbackend.subscription.stripe_subscription import StripeServiceDependency
 from fixbackend.workspaces.dependencies import UserWorkspaceDependency
+from fixbackend.utils import fassert
 
 AddUrlName = "aws-marketplace-subscription-add"
 BackFromStripe = "back-from-stripe"
@@ -104,7 +105,7 @@ def subscription_router() -> APIRouter:
     @router.post("/subscriptions/stripe/events", include_in_schema=False)
     async def stripe_callback(request: Request, stripe_service: StripeServiceDependency) -> Response:
         signature = request.headers.get("Stripe-Signature")
-        assert signature is not None, "No Stripe-Signature header found"
+        fassert(signature is not None, "No Stripe-Signature header found")
         js_bytes = await request.body()
         try:
             await stripe_service.handle_event(js_bytes.decode("utf-8"), signature)

--- a/fixbackend/subscription/stripe_subscription.py
+++ b/fixbackend/subscription/stripe_subscription.py
@@ -52,7 +52,7 @@ from fixbackend.ids import (
 from fixbackend.subscription.models import StripeSubscription
 from fixbackend.subscription.subscription_repository import StripeCustomerRepository, SubscriptionRepository
 from fixbackend.types import AsyncSessionMaker
-from fixbackend.utils import start_of_next_period, uid
+from fixbackend.utils import start_of_next_period, uid, fassert
 from fixbackend.workspaces.models import Workspace
 from fixbackend.workspaces.repository import WorkspaceRepository
 
@@ -132,7 +132,7 @@ class StripeClient:  # pragma: no cover
 
     async def checkout_session(self, **params: Unpack[stripe.checkout.Session.CreateParams]) -> str:
         session = await stripe.checkout.Session.create_async(**params)
-        assert session.url is not None, "No session URL?"
+        fassert(session.url is not None, "No session URL?")
         return session.url
 
     async def billing_portal_session(self, **params: Unpack[stripe.billing_portal.Session.CreateParams]) -> str:
@@ -377,7 +377,7 @@ class StripeServiceImpl(StripeService):
         customer_id = await self.stripe_customer_repo.get(workspace.id)
         if customer_id is None:
             owner = await self.user_repo.get(workspace.owner_id)
-            assert owner is not None, f"Workspace {workspace.id} does not have an owner?"
+            fassert(owner is not None, f"Workspace {workspace.id} does not have an owner?")
             customer_id = await self.client.create_customer(workspace.id, email=owner.email)
             await self.stripe_customer_repo.create(workspace.id, customer_id)
         return customer_id

--- a/fixbackend/utils.py
+++ b/fixbackend/utils.py
@@ -92,3 +92,8 @@ def batch(items: Iterable[AnyT], n: int = 50) -> Iterator[List[AnyT]]:
     it = iter(items)
     while chunk := list(islice(it, n)):
         yield chunk
+
+
+def fassert(condition: Any, message: Any = "") -> None:
+    if not condition:
+        raise AssertionError(message)

--- a/fixbackend/utils.py
+++ b/fixbackend/utils.py
@@ -34,7 +34,7 @@ import uuid
 from collections import defaultdict
 from datetime import datetime, timezone, timedelta
 from itertools import islice
-from typing import Optional, Callable, TypeVar, Iterable, Dict, List, Any, Iterator
+from typing import Optional, Callable, TypeVar, Iterable, Dict, List, Any, Iterator, TypeGuard
 from uuid import UUID
 
 from fixcloudutils.util import utc
@@ -94,7 +94,7 @@ def batch(items: Iterable[AnyT], n: int = 50) -> Iterator[List[AnyT]]:
         yield chunk
 
 
-def fassert(condition: Any, message: Any = "") -> None:
-    assert condition, message
+def fassert(condition: Any, message: Any = "") -> TypeGuard[bool]:
     if not condition:
         raise AssertionError(message)
+    return True

--- a/fixbackend/utils.py
+++ b/fixbackend/utils.py
@@ -95,5 +95,6 @@ def batch(items: Iterable[AnyT], n: int = 50) -> Iterator[List[AnyT]]:
 
 
 def fassert(condition: Any, message: Any = "") -> None:
+    assert condition, message
     if not condition:
         raise AssertionError(message)

--- a/migrations/versions/2023-08-30T13:10:07Z_add_user_tables.py
+++ b/migrations/versions/2023-08-30T13:10:07Z_add_user_tables.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2023-08-30 13:10:07.034525+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-08-31T14:38:18Z_add_organization_models.py
+++ b/migrations/versions/2023-08-31T14:38:18Z_add_organization_models.py
@@ -5,6 +5,7 @@ Revises: 5eaf979cfb28
 Create Date: 2023-08-31 14:38:18.402653+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-09-20T09:32:21Z_add_externalid_to_org.py
+++ b/migrations/versions/2023-09-20T09:32:21Z_add_externalid_to_org.py
@@ -5,6 +5,7 @@ Revises: 9bd6d9dc6957
 Create Date: 2023-09-20 09:32:21.019505+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-09-21T10:28:33Z_use_a_separate_tenant_id.py
+++ b/migrations/versions/2023-09-21T10:28:33Z_use_a_separate_tenant_id.py
@@ -5,6 +5,7 @@ Revises: aba43062e638
 Create Date: 2023-09-21 10:28:33.594279+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-09-25T10:53:08Z_graph_database_access.py
+++ b/migrations/versions/2023-09-25T10:53:08Z_graph_database_access.py
@@ -5,6 +5,7 @@ Revises: a1d4ec210f18
 Create Date: 2023-09-25 10:53:08.032138+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-09-26T19:17:30Z_drop_tenant_id.py
+++ b/migrations/versions/2023-09-26T19:17:30Z_drop_tenant_id.py
@@ -5,6 +5,7 @@ Revises: 995b51027ef6
 Create Date: 2023-09-26 19:17:30.837516+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-09-27T15:27:39Z_add_cloud_account.py
+++ b/migrations/versions/2023-09-27T15:27:39Z_add_cloud_account.py
@@ -5,6 +5,7 @@ Revises: b768e81c0d5c
 Create Date: 2023-09-27 15:27:39.397364+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-09-28T13:38:59Z_add_next_run_table.py
+++ b/migrations/versions/2023-09-28T13:38:59Z_add_next_run_table.py
@@ -5,6 +5,7 @@ Revises: 9f0f5d8ec3d5
 Create Date: 2023-09-28 13:38:59.635966+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-09-29T09:53:37Z_add_metering_data.py
+++ b/migrations/versions/2023-09-29T09:53:37Z_add_metering_data.py
@@ -5,6 +5,7 @@ Revises: e3ddf05cd115
 Create Date: 2023-09-29 09:53:37.058826+00:00
 
 """
+
 from typing import Sequence, Union
 
 import fastapi_users_db_sqlalchemy

--- a/migrations/versions/2023-10-01T09:13:03Z_graph_database_name.py
+++ b/migrations/versions/2023-10-01T09:13:03Z_graph_database_name.py
@@ -5,6 +5,7 @@ Revises: 9b414d0c477f
 Create Date: 2023-10-01 09:13:03.651887+00:00
 
 """
+
 #  Copyright (c) 2023. Some Engineering
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Affero General Public License as published by

--- a/migrations/versions/2023-10-02T09:29:13Z_metering_record_per_account.py
+++ b/migrations/versions/2023-10-02T09:29:13Z_metering_record_per_account.py
@@ -5,6 +5,7 @@ Revises: 3b44ef1c41a0
 Create Date: 2023-10-02 09:29:13.062663+00:00
 
 """
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa

--- a/migrations/versions/2023-10-02T12:17:40Z_add_json_kv_store.py
+++ b/migrations/versions/2023-10-02T12:17:40Z_add_json_kv_store.py
@@ -5,6 +5,7 @@ Revises: 3b44ef1c41a0
 Create Date: 2023-10-02 12:17:40.712823+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-10-17T09:03:56Z_session_entity_genesis.py
+++ b/migrations/versions/2023-10-17T09:03:56Z_session_entity_genesis.py
@@ -5,6 +5,7 @@ Revises: 9b482c179740
 Create Date: 2023-10-17 09:03:56.141766+00:00
 
 """
+
 from typing import Sequence, Union
 
 import fastapi_users_db_sqlalchemy

--- a/migrations/versions/2023-10-17T12:15:06Z_add_the_next_tenant_run_table.py
+++ b/migrations/versions/2023-10-17T12:15:06Z_add_the_next_tenant_run_table.py
@@ -5,6 +5,7 @@ Revises: 9b482c179740
 Create Date: 2023-10-16 12:15:06.362132+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-10-18T10:10:08Z_add_compute_to_json_store.py
+++ b/migrations/versions/2023-10-18T10:10:08Z_add_compute_to_json_store.py
@@ -5,6 +5,7 @@ Revises: 337d9a21e53c
 Create Date: 2023-10-18 10:10:08.859003+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-10-19T16:21:19Z_add_last_scan_repo.py
+++ b/migrations/versions/2023-10-19T16:21:19Z_add_last_scan_repo.py
@@ -5,6 +5,7 @@ Revises: 2cbb6dcf9d01
 Create Date: 2023-10-19 16:21:19.099419+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-10-20T13:03:37Z_add_name_to_cloud_account_repo.py
+++ b/migrations/versions/2023-10-20T13:03:37Z_add_name_to_cloud_account_repo.py
@@ -5,6 +5,7 @@ Revises: 4df8ea080f3e
 Create Date: 2023-10-20 13:03:37.370998+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-10-23T12:43:21Z_billing_entity.py
+++ b/migrations/versions/2023-10-23T12:43:21Z_billing_entity.py
@@ -5,6 +5,7 @@ Revises: 69f29fc94a5c
 Create Date: 2023-10-23 12:43:21.899358+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-10-27T12:46:40Z_add_configured_flag_to_cloud_account.py
+++ b/migrations/versions/2023-10-27T12:46:40Z_add_configured_flag_to_cloud_account.py
@@ -5,6 +5,7 @@ Revises: d9be24f944dc
 Create Date: 2023-10-27 12:46:40.781041+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-11-08T16:10:12Z_cloud_account_state_machine.py
+++ b/migrations/versions/2023-11-08T16:10:12Z_cloud_account_state_machine.py
@@ -5,6 +5,7 @@ Revises: e5a452318fa7
 Create Date: 2023-11-08 16:10:12.694233+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-11-16T16:57:50Z_merge_last_scan_table_to_cloud_account.py
+++ b/migrations/versions/2023-11-16T16:57:50Z_merge_last_scan_table_to_cloud_account.py
@@ -5,6 +5,7 @@ Revises: 886ab1ab881e
 Create Date: 2023-11-16 16:57:50.123194+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-11-17T15:35:27Z_add_created_at_updated_at_to_cloud_.py
+++ b/migrations/versions/2023-11-17T15:35:27Z_add_created_at_updated_at_to_cloud_.py
@@ -5,6 +5,7 @@ Revises: b33942763df4
 Create Date: 2023-11-17 15:35:27.215609+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-12-07T12:14:35Z_update_workspace_invites.py
+++ b/migrations/versions/2023-12-07T12:14:35Z_update_workspace_invites.py
@@ -5,6 +5,7 @@ Revises: d294f6e4b5dc
 Create Date: 2023-12-07 12:14:35.061355+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-12-11T12:17:42Z_add_security_tier_to_workspace.py
+++ b/migrations/versions/2023-12-11T12:17:42Z_add_security_tier_to_workspace.py
@@ -5,6 +5,7 @@ Revises: 1ccf5fc88e67
 Create Date: 2023-12-11 12:17:42.072422+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-12-14T12:16:09Z_increase_maximum_aws_name_size_in_cloud_.py
+++ b/migrations/versions/2023-12-14T12:16:09Z_increase_maximum_aws_name_size_in_cloud_.py
@@ -5,6 +5,7 @@ Revises: 2354e2e14300
 Create Date: 2023-12-14 12:16:09.677052+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-12-14T12:47:37Z_sync_metering_records_fields_lengths_to_.py
+++ b/migrations/versions/2023-12-14T12:47:37Z_sync_metering_records_fields_lengths_to_.py
@@ -5,6 +5,7 @@ Revises: fa6b6587c907
 Create Date: 2023-12-14 12:47:37.101341+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/migrations/versions/2023-12-21T15:20:40Z_add_a_unique_contstaint_to_workspace_in_.py
+++ b/migrations/versions/2023-12-21T15:20:40Z_add_a_unique_contstaint_to_workspace_in_.py
@@ -5,6 +5,7 @@ Revises: 917c74178e81
 Create Date: 2023-12-21 15:20:40.941195+00:00
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/tests/fixbackend/utils_test.py
+++ b/tests/fixbackend/utils_test.py
@@ -27,10 +27,11 @@
 #
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import pytest
 from datetime import datetime, timezone
 
 
-from fixbackend.utils import start_of_next_month, batch
+from fixbackend.utils import start_of_next_month, batch, fassert
 
 
 def test_start_of_next_month() -> None:
@@ -52,3 +53,21 @@ def test_batch() -> None:
     check_size(100, 1)
     check_size(1, 100)
     check_size(5, 20)
+
+
+def test_fassert():
+    fassert(1 == 1, "This should not fail")
+
+    with pytest.raises(AssertionError, match="This should fail"):
+        fassert(1 == 2, "This should fail")
+
+    fassert(2 > 1)
+
+    with pytest.raises(AssertionError):
+        fassert(1 > 2)
+
+    with pytest.raises(AssertionError, match="Condition is false"):
+        fassert(None, "Condition is false")
+
+    with pytest.raises(AssertionError, match="List is empty"):
+        fassert([], "List is empty")


### PR DESCRIPTION
# Description

Replaces Python built-in `assert` with Fix `fassert` in production code, so it doesn't get removed when running optimized bytecode.

P.S. `black` also reformatted a bunch of migrations with missing newlines - ignore those.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `nox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
