### PR TITLE
Silence GCP degradation

### DIFF
--- a/fixbackend/cloud_accounts/service.py
+++ b/fixbackend/cloud_accounts/service.py
@@ -473,17 +473,18 @@ class CloudAccountService(Service):
                     if workspace is None:
                         log.error(f"Workspace {degraded_event.tenant_id} not found, can't send email")
                         return None
-                    await self.notification_service.send_message_to_workspace(
-                        workspace_id=degraded_event.tenant_id,
-                        message=email.AccountDegraded(
-                            cloud=degraded_event.cloud,
-                            cloud_account_id=degraded_event.account_id,
-                            tenant_id=degraded_event.tenant_id,
-                            workspace_name=workspace.name,
-                            account_name=degraded_event.account_name,
-                            cf_stack_deleted=degraded_event.reason == DegradationReason.stack_deleted,
-                        ),
-                    )
+                    if degraded_event.cloud != CloudNames.GCP:
+                        await self.notification_service.send_message_to_workspace(
+                            workspace_id=degraded_event.tenant_id,
+                            message=email.AccountDegraded(
+                                cloud=degraded_event.cloud,
+                                cloud_account_id=degraded_event.account_id,
+                                tenant_id=degraded_event.tenant_id,
+                                workspace_name=workspace.name,
+                                account_name=degraded_event.account_name,
+                                cf_stack_deleted=degraded_event.reason == DegradationReason.stack_deleted,
+                            ),
+                        )
                     await send_pub_sub_message(degraded_event)
 
                 case ProductTierChanged.kind:


### PR DESCRIPTION
# Description

Something is wrong with Email sending for GCP account degradation. In the past 6h I received 42 Emails for the same account and the system won't shut up about it.

<img width="494" alt="image" src="https://github.com/user-attachments/assets/49ebb0f8-48ff-487e-ab92-2e20e24a7b72">

This temporarily patches out the GCP email sending for degraded accounts until we have a proper fix.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `nox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
